### PR TITLE
Properly re-export the build directory

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -106,3 +106,7 @@ echo "Building runtime environment for graphicsmagick" | arrow
 mkdir -p $BUILD_DIR/.profile.d
 echo "export PATH=\"\$HOME/bin:\$PATH\"" > $BUILD_DIR/.profile.d/graphicsmagick.sh
 echo "export LD_LIBRARY_PATH=\"/app/vendor/nasm/lib/:/app/vendor/libjpeg-turbo/lib/:/app/vendor/zlib/lib/:/app/vendor/libpng/lib/:/app/vendor/graphicsmagick/lib/:\$LD_LIBRARY_PATH\"" >> $BUILD_DIR/.profile.d/graphicsmagick.sh
+
+cat <<EOF > export
+export PATH=$BUILD_DIR/bin:$PATH
+EOF


### PR DESCRIPTION
This PR makes sure that the build directory's bin gets added to the path that is re-exported so that subsequent buildpacks in a multi-buildpack environment can access `gm`

I believe this also fixes #18 
