### PR TITLE
Echo buildpack name as heroku's multi support says detect script must

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -1,4 +1,5 @@
 #! /bin/bash
 
 # this buildpack can always be used
+echo "GraphicsMagick"
 exit 0


### PR DESCRIPTION
Minor change to Heroku buildpack API requires the detect script to output something to stdout in order to work with Heroku's built-in multi-buildpack support.

From API doc (https://devcenter.heroku.com/articles/buildpack-api)

> If the exit code is 0, the script must print a human-readable framework name to stdout.

Fixes #20